### PR TITLE
Enable `--server-create-timeout` option

### DIFF
--- a/lib/chef/knife/cloud/vra_service.rb
+++ b/lib/chef/knife/cloud/vra_service.rb
@@ -50,7 +50,7 @@ class Chef
         def create_server(options={})
           submitted_request = catalog_request(options).submit
           ui.msg("Catalog request #{submitted_request.id} submitted.")
-          wait_for_request(submitted_request, options[:wait_time], options[:refresh_rate])
+          wait_for_request(submitted_request, options[:wait_time].to_i, options[:refresh_rate])
           ui.msg("Catalog request complete.\n")
           request_summary(submitted_request)
 

--- a/lib/chef/knife/vra_server_create.rb
+++ b/lib/chef/knife/vra_server_create.rb
@@ -46,6 +46,11 @@ class Chef
                long:        '--requested-for LOGIN',
                description: 'The login to list as the owner of this resource. Will default to the vra_username parameter'
 
+        option :server_create_timeout,
+               long:        '--server-create-timeout SECONDS',
+               description: 'number of seconds to wait for the server to complete',
+               default:     600
+
         option :subtenant_id,
                long:        '--subtenant-id ID',
                description: 'The subtenant ID (a.k.a "business group") to list as the owner of this resource. ' \


### PR DESCRIPTION
This PR is exposing the knife-option `--server-create-timeout` and also making sure whenever we call `wait_for_request ` we pass an integer. 