### PR TITLE
Added pagination size option and a higher-than-normal default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ Current request status: IN_PROGRESS...
 ...
 ```
 
+### Known Issue: Pagination
+
+A bug in vRA v6 (as late as v6.2.1) causes resource/server lists to potentially return duplicate items and omit items in the returned data. This appears to be a bug in the pagination code in vRA and was initially discovered and discussed [in this GitHub issue](https://github.com/chef-partners/vmware-vra-gem/issues/10). `knife-vrealize` tries to work around this by setting a higher-than-normal page size of 200 items.  However, if you have more items in your returned data than this, you can attempt to work around this further by using:
+
+```
+--page-size NUMBER_OF_ITEMS_PER_PAGE
+```
+
+
 ## vRealize Orchestrator (vRO)
 
 ### Configuration

--- a/lib/chef/knife/cloud/vra_service.rb
+++ b/lib/chef/knife/cloud/vra_service.rb
@@ -35,6 +35,7 @@ class Chef
           @base_url   = options[:base_url]
           @tenant     = options[:tenant]
           @verify_ssl = options[:verify_ssl]
+          @page_size  = options[:page_size]
         end
 
         def connection
@@ -43,6 +44,7 @@ class Chef
             username:   @username,
             password:   @password,
             tenant:     @tenant,
+            page_size:  @page_size,
             verify_ssl: @verify_ssl
           )
         end

--- a/lib/chef/knife/cloud/vra_service_helpers.rb
+++ b/lib/chef/knife/cloud/vra_service_helpers.rb
@@ -25,10 +25,11 @@ class Chef
         include Chef::Knife::Cloud::Helpers
 
         def create_service_instance
-          Chef::Knife::Cloud::VraService.new(username: locate_config_value(:vra_username),
-                                             password: locate_config_value(:vra_password),
-                                             base_url: locate_config_value(:vra_base_url),
-                                             tenant:   locate_config_value(:vra_tenant),
+          Chef::Knife::Cloud::VraService.new(username:  locate_config_value(:vra_username),
+                                             password:  locate_config_value(:vra_password),
+                                             base_url:  locate_config_value(:vra_base_url),
+                                             tenant:    locate_config_value(:vra_tenant),
+                                             page_size: locate_config_value(:vra_page_size),
                                              verify_ssl: verify_ssl?)
         end
 

--- a/lib/chef/knife/cloud/vra_service_options.rb
+++ b/lib/chef/knife/cloud/vra_service_options.rb
@@ -41,6 +41,12 @@ class Chef
               boolean:     true,
               default:     false
 
+            option :vra_page_size,
+              long:        '--page-size NUM_OF_ITEMS',
+              description: 'Maximum number of items to fetch from the vRA API when pagination is forced',
+              default:     200,
+              proc:        proc { |page_size| page_size.to_i }
+
             option :request_refresh_rate,
               long:        '--request-refresh-rate SECS',
               description: 'Number of seconds to sleep between each check of the request status, defaults to 2',

--- a/spec/unit/cloud/vra_service_helpers_spec.rb
+++ b/spec/unit/cloud/vra_service_helpers_spec.rb
@@ -39,6 +39,7 @@ describe 'Chef::Knife::Cloud::VraServiceHelpers' do
       allow(subject).to receive(:locate_config_value).with(:vra_password).and_return('mypassword')
       allow(subject).to receive(:locate_config_value).with(:vra_base_url).and_return('https://vra.corp.local')
       allow(subject).to receive(:locate_config_value).with(:vra_tenant).and_return('mytenant')
+      allow(subject).to receive(:locate_config_value).with(:vra_page_size).and_return(50)
       allow(subject).to receive(:locate_config_value).with(:vra_disable_ssl_verify).and_return(false)
 
       expect(Chef::Knife::Cloud::VraService).to receive(:new)
@@ -46,6 +47,7 @@ describe 'Chef::Knife::Cloud::VraServiceHelpers' do
               password:   'mypassword',
               base_url:   'https://vra.corp.local',
               tenant:     'mytenant',
+              page_size:  50,
               verify_ssl: true)
 
       subject.create_service_instance


### PR DESCRIPTION
As documented in https://github.com/chef-partners/vmware-vra-gem/issues/10,
there is a bug in the vRA API that causes duplicate entries to be returned
when the results are paginated.  This sets a high page size to avoid that,
but for users that have more than 200 items, this provides the ability
for the user to override the page size until VMware corrects the bug.