### PR TITLE
Bug-fix for handling extra parameters

### DIFF
--- a/lib/chef/knife/cloud/vra_service.rb
+++ b/lib/chef/knife/cloud/vra_service.rb
@@ -128,9 +128,9 @@ class Chef
           catalog_request.notes         = options[:notes]         unless options[:notes].nil?
           catalog_request.subtenant_id  = options[:subtenant_id]  unless options[:subtenant_id].nil?
 
-          if options[:vra_extra_params]
-            options[:vra_extra_params].each do |key, value_data|
-              catalog_request.set_parameter(key, value_data[:type], value_data[:value])
+          if options[:extra_params]
+            options[:extra_params].each do |param|
+              catalog_request.set_parameter(param[:key], param[:type], param[:value])
             end
           end
 

--- a/lib/chef/knife/vra_server_create.rb
+++ b/lib/chef/knife/vra_server_create.rb
@@ -113,7 +113,7 @@ class Chef
         end
 
         def extra_params
-          return unless Chef::Config[:knife][:vra_extra_params]
+          return if Chef::Config[:knife][:vra_extra_params].nil? || Chef::Config[:knife][:vra_extra_params].empty?
 
           Chef::Config[:knife][:vra_extra_params].each_with_object([]) do |(key, value_str), memo|
             type, value = value_str.split(':')

--- a/lib/chef/knife/vra_server_create.rb
+++ b/lib/chef/knife/vra_server_create.rb
@@ -115,13 +115,10 @@ class Chef
         def extra_params
           return unless Chef::Config[:knife][:vra_extra_params]
 
-          params = []
-          Chef::Config[:knife][:vra_extra_params].each do |key, value_str|
+          Chef::Config[:knife][:vra_extra_params].each_with_object([]) do |(key, value_str), memo|
             type, value = value_str.split(':')
-            params << { key: key, type: type, value: value }
+            memo << { key: key, type: type, value: value }
           end
-
-          params
         end
 
         def validate_extra_params!

--- a/spec/unit/cloud/vra_service_spec.rb
+++ b/spec/unit/cloud/vra_service_spec.rb
@@ -240,10 +240,10 @@ describe Chef::Knife::Cloud::VraService do
                                 cpus: 1,
                                 memory: 512,
                                 requested_for: 'myuser@corp.local',
-                                vra_extra_params: {
-                                  'key1' => { type: 'string', value: 'value1' },
-                                  'key2' => { type: 'integer', value: '2' }
-                                })
+                                extra_params: [
+                                  { key: 'key1', type: 'string', value: 'value1' },
+                                  { key: 'key2', type: 'integer', value: '2' }
+                                ])
       end
     end
   end

--- a/spec/unit/vra_server_create_spec.rb
+++ b/spec/unit/vra_server_create_spec.rb
@@ -22,6 +22,10 @@ require 'support/shared_examples_for_command'
 require 'support/shared_examples_for_servercreatecommand'
 
 describe Chef::Knife::Cloud::VraServerCreate do
+  before(:each) do
+    Chef::Config.reset
+  end
+
   argv = []
   argv += %w(--cpus 1)
   argv += %w(--memory 512)
@@ -60,14 +64,33 @@ describe Chef::Knife::Cloud::VraServerCreate do
   end
 
   describe '#extra_params' do
-    it 'parses extra parameters properly' do
-      params = subject.extra_params
-      expect(params[0][:key]).to eq 'key1'
-      expect(params[0][:type]).to eq 'string'
-      expect(params[0][:value]).to eq 'value1'
-      expect(params[1][:key]).to eq 'key2'
-      expect(params[1][:type]).to eq 'integer'
-      expect(params[1][:value]).to eq '2'
+    context 'when there are no extra params' do
+      before do
+        Chef::Config[:knife][:vra_extra_params] = {}
+      end
+
+      it 'returns nil' do
+        expect(subject.extra_params).to eq(nil)
+      end
+    end
+
+    context 'when extra params are provided' do
+      before do
+        Chef::Config[:knife][:vra_extra_params] = {
+          'key1' => 'string:value1',
+          'key2' => 'integer:2'
+        }
+      end
+
+      it 'parses extra parameters properly' do
+        params = subject.extra_params
+        expect(params[0][:key]).to eq 'key1'
+        expect(params[0][:type]).to eq 'string'
+        expect(params[0][:value]).to eq 'value1'
+        expect(params[1][:key]).to eq 'key2'
+        expect(params[1][:type]).to eq 'integer'
+        expect(params[1][:value]).to eq '2'
+      end
     end
   end
 


### PR DESCRIPTION
The wrong hash key was used to search for the parameters, and the
format used between methods was inconsistent.  This corrects
both issues and also slims down the VraServerCreate#extra_params
method using each_with_object.