### PR TITLE
Adding logic to fall back to the vRA resource/server name

### DIFF
--- a/lib/chef/knife/vra_server_create.rb
+++ b/lib/chef/knife/vra_server_create.rb
@@ -109,7 +109,7 @@ class Chef
           super
 
           config[:chef_node_name] = locate_config_value(:chef_node_name) ? locate_config_value(:chef_node_name) : server.name
-          config[:bootstrap_ip_address] = server.ip_addresses.first
+          config[:bootstrap_ip_address] = hostname_for_server
         end
 
         def extra_params
@@ -129,6 +129,12 @@ class Chef
             raise ArgumentError, "Invalid parameter type for #{param[:key]} - must be string or integer" unless
               param[:type] == 'string' || param[:type] == 'integer'
           end
+        end
+
+        def hostname_for_server
+          ip_address = server.ip_addresses.first
+
+          ip_address.nil? ? server.name : ip_address
         end
       end
     end

--- a/spec/unit/vra_server_create_spec.rb
+++ b/spec/unit/vra_server_create_spec.rb
@@ -147,4 +147,24 @@ describe Chef::Knife::Cloud::VraServerCreate do
       end
     end
   end
+
+  describe '#hostname_for_server' do
+    let(:server)       { double('server') }
+    let(:ip_addresses) { [ '1.2.3.4' ] }
+
+    it 'returns the IP address if it exists' do
+      allow(subject).to receive(:server).and_return(server)
+      allow(server).to receive(:ip_addresses).and_return(ip_addresses)
+
+      expect(subject.hostname_for_server).to eq('1.2.3.4')
+    end
+
+    it 'returns the hostname if the IP address is missing' do
+      allow(subject).to receive(:server).and_return(server)
+      allow(server).to receive(:ip_addresses).and_return([])
+      allow(server).to receive(:name).and_return('test_name')
+
+      expect(subject.hostname_for_server).to eq('test_name')
+    end
+  end
 end


### PR DESCRIPTION
If the IP address doesn't exist on the vRA resource record,
this will fall back to using the vRA resource name, hoping
that the name itself is a valid FQDN for the server in question.